### PR TITLE
Group1 - Variable init changes

### DIFF
--- a/config/virtualbox
+++ b/config/virtualbox
@@ -80,7 +80,6 @@ vboxmanage hostonlyif create
 # By default 'vboxmanage hostonlyif create' will create 'vboxnet0' or 'VirtualBox Host-Only Ethernet Adapter' on the first call, then 'vboxnet1' or 'VirtualBox Host-Only Ethernet Adapter #2' on the next, etc.
 # To check the default name and find info on what was created type: VBoxManage list hostonlyifs
 # If it is not vboxnet# by default, you can delete it by typing: VBoxManage remove <NETWORKNAME>
-# To rename it, try: modifyvm <OLDNETWORKNAME> --name vboxnet1
 # More info can be found here https://www.virtualbox.org/manual/ch08.html
 # Assuming vboxnet1 was created
 vboxmanage dhcpserver add --ifname vboxnet1 --ip 192.168.56.2 --netmask 255.255.255.0 --lowerip 192.168.56.3 --upperip 192.168.56.254 --enable

--- a/config/virtualbox
+++ b/config/virtualbox
@@ -69,7 +69,8 @@ export VM_DISK_DIR=$HOME/vm_disks
 # Assumes the .vdi file is in $HOME/vm_disks. If you extracted
 # it in $HOME/vm_disks, move it out of the folder it comes
 # extracted in.
-export VDI="$VM_DISK_DIR/Ubuntu*\(64bit\).vdi"
+# **If this does not match the name of your file in $HOME/vm_disks, change it here.**
+export VDI="$VM_DISK_DIR/Ubuntu 16.04.5 (64bit).vdi"
 export VMNAME=k_grok-group1
 # determine your host's primary network adapter ...
 # this may work on Linux

--- a/config/virtualbox
+++ b/config/virtualbox
@@ -97,7 +97,6 @@ vboxmanage hostonlyif create
 # It being named "VirtualBox Host-Only Ethernet Adapter" is fine as well,
 # just make sure you put the name in quotes in $HOST_INTERFACE_NAME above.
 # More info can be found here https://www.virtualbox.org/manual/ch08.html
-# Assuming vboxnet1 was created
 vboxmanage dhcpserver add --ifname "$HOST_INTERFACE_NAME" --ip 192.168.56.2 --netmask 255.255.255.0 --lowerip 192.168.56.3 --upperip 192.168.56.254 --enable
 
 # For more info about these instructions, see:

--- a/config/virtualbox
+++ b/config/virtualbox
@@ -70,7 +70,7 @@ export VM_DISK_DIR=$HOME/vm_disks
 # it in $HOME/vm_disks, move it out of the folder it comes
 # extracted in.
 export VDI="$VM_DISK_DIR/Ubuntu*\(64bit\).vdi"
-export VMNAME=k_grok
+export VMNAME=k_grok-group1
 # determine your host's primary network adapter ...
 # this may work on Linux
 export HOST_ADAPTER=$(ip link show up | grep "<BROAD" | cut -f2 -d":")

--- a/config/virtualbox
+++ b/config/virtualbox
@@ -66,19 +66,32 @@
 
 # Variable Init phase
 export VM_DISK_DIR=$HOME/vm_disks
-export VDI="$VM_DISK_DIR/Ubuntu 16.10 Yakkety (64bit).vdi"
+# Assumes the .vdi file is in $HOME/vm_disks. If you extracted
+# it in $HOME/vm_disks, move it out of the folder it comes
+# extracted in.
+export VDI="$VM_DISK_DIR/Ubuntu*(64bit).vdi"
 export VMNAME=k_grok
 # determine your host's primary network adapter ...
 # this may work on Linux
 export HOST_ADAPTER=$(ip link show up | grep "<BROAD" | cut -f2 -d":")
 # this may work on Mac OS X
 export HOST_ADAPTER=$(ifconfig | grep -B4 "status: active" | grep -B3 "inet " | head -1 | cut -f1 -d":")
+# Don't assume the name of the Host-Interface Network (hostonlyif) network
+# since it may differ on different operating systems
+export HOST_INTERFACE_NAME="vboxnet0"
 
 # Host configuration phase
 # On your host:
+# You can list the Host-Interface networks on your system by running:
+# vboxmanage list hostonlyifs
+# You can grep the name out like so:
+# vboxmanage list hostonlyifs | grep "Name:" | head -n 1
+# Note if vboxmanage hostonlyif create is not commented out,
+# after you've created a Host-Interface Network this will
+# continue to successive Host-Interface networks each time this
+# script is run.
 vboxmanage hostonlyif create
-# Assuming vboxnet1 was created
-vboxmanage dhcpserver add --ifname vboxnet1 --ip 192.168.56.2 --netmask 255.255.255.0 --lowerip 192.168.56.3 --upperip 192.168.56.254 --enable
+vboxmanage dhcpserver add --ifname "$HOST_INTERFACE_NAME" --ip 192.168.56.2 --netmask 255.255.255.0 --lowerip 192.168.56.3 --upperip 192.168.56.254 --enable
 
 # For more info about these instructions, see:
 # https://www.virtualbox.org/manual/ch08.html
@@ -98,7 +111,7 @@ vboxmanage storageattach $VMNAME --storagectl SATA --port 0 --device 0 --type hd
 # VM network config phase
 vboxmanage modifyvm $VMNAME --nic1 nat --nictype1 virtio
 vboxmanage modifyvm $VMNAME --nic2 hostonly --nictype2 82540EM
-vboxmanage modifyvm $VMNAME --hostonlyadapter2 vboxnet1
+vboxmanage modifyvm $VMNAME --hostonlyadapter2 "$HOST_INTERFACE_NAME"
 
 # VM console config phase (optional)
 # send serial console to a log file
@@ -120,7 +133,7 @@ vboxmanage startvm $VMNAME
 # apt upgrade
 # apt install openssh-server git
 #
-# ssh osboxes@$(arp -a | perl -ne '/\((.*)\) .*[0-9a-f] on vboxnet0 ifscope \[ethernet\]/ && print $1')
+# ssh osboxes@$(arp -a | perl -ne '/\((.*)\) .*[0-9a-f] on "$HOST_INTERFACE_NAME" ifscope \[ethernet\]/ && print $1')
 # mkdir ~/src
 # cd ~/src
 # git clone https://github.com/agshew/k_grok.git

--- a/config/virtualbox
+++ b/config/virtualbox
@@ -69,7 +69,7 @@ export VM_DISK_DIR=$HOME/vm_disks
 # Assumes the .vdi file is in $HOME/vm_disks. If you extracted
 # it in $HOME/vm_disks, move it out of the folder it comes
 # extracted in.
-export VDI="$VM_DISK_DIR/Ubuntu*(64bit).vdi"
+export VDI="$VM_DISK_DIR/Ubuntu*\(64bit\).vdi"
 export VMNAME=k_grok
 # determine your host's primary network adapter ...
 # this may work on Linux

--- a/config/virtualbox
+++ b/config/virtualbox
@@ -93,7 +93,7 @@ export HOST_INTERFACE_NAME="vboxnet0"
 vboxmanage hostonlyif create
 # By default 'vboxmanage hostonlyif create' will create 'vboxnet0' or 'VirtualBox Host-Only Ethernet Adapter'
 # on the first call, then 'vboxnet1' or 'VirtualBox Host-Only Ethernet Adapter #2' on the next, etc.
-# If it is not vboxnet# by default, you can delete it by typing: VBoxManage remove <NETWORKNAME>
+# If it is not vboxnet# by default, you can delete it by typing: VBoxManage hostonlyif remove <NETWORKNAME>
 # It being named "VirtualBox Host-Only Ethernet Adapter" is fine as well,
 # just make sure you put the name in quotes in $HOST_INTERFACE_NAME above.
 # More info can be found here https://www.virtualbox.org/manual/ch08.html

--- a/config/virtualbox
+++ b/config/virtualbox
@@ -77,6 +77,11 @@ export HOST_ADAPTER=$(ifconfig | grep -B4 "status: active" | grep -B3 "inet " | 
 # Host configuration phase
 # On your host:
 vboxmanage hostonlyif create
+# By default 'vboxmanage hostonlyif create' will create 'vboxnet0' or 'VirtualBox Host-Only Ethernet Adapter' on the first call, then 'vboxnet1' or 'VirtualBox Host-Only Ethernet Adapter #2' on the next, etc.
+# To check the default name and find info on what was created type: VBoxManage list hostonlyifs
+# If it is not vboxnet# by default, you can delete it by typing: VBoxManage remove <NETWORKNAME>
+# To rename it, try: modifyvm <OLDNETWORKNAME> --name vboxnet1
+# More info can be found here https://www.virtualbox.org/manual/ch08.html
 # Assuming vboxnet1 was created
 vboxmanage dhcpserver add --ifname vboxnet1 --ip 192.168.56.2 --netmask 255.255.255.0 --lowerip 192.168.56.3 --upperip 192.168.56.254 --enable
 


### PR DESCRIPTION
This Pull request includes changes to the Variable Init and Host-Interface network

Relevant comments from the virtualbox file:

Make sure to change `$VDI` to match the name of your file in `$VM_DISK_DIR`
Edit `$HOST_INTERFACE_NAME` to match the name of the `hostonlyif` (Host-Only) network.

If you've run this script multiple times, and the script reached past
the VM creation phase, the script is going to fail, because its already
generated a Machine Settings file that matches the `$VMNAME`.

You can reset these settings by removing the VM:
List all VMs:
`vboxmanage list vms`
Delete the one that was misconfigured:
`vboxmanage unregistervm <VMNAME | VMID> -delete`
Then, make sure the `Ubuntu....(64bit).vdi` file is in `$VM_DISK_DIR` (or preferably, replace it wish a freshly downloaded one), and run the script again.
